### PR TITLE
Minor fixes to avoid bad behavior

### DIFF
--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -47,7 +47,7 @@ const DefaultCard = (({item, handler, itemRef, ...props}) => {
               <div className="mosaic-info">
                 <div className="mosaic-title">
                   <h5>{item.name}</h5>
-                  {item.region}
+                  {item.homepage_url}
                 </div>
                 <div className="mosaic-stars">
                   { _.isNumber(item.stars) && item.stars &&

--- a/src/components/RegionFilterContainer.js
+++ b/src/components/RegionFilterContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import ComboboxMultiSelector from './ComboboxMultiSelector';
+import TreeSelector from './TreeSelector';
 import { changeFilter } from '../reducers/mainReducer.js';
 import { options } from '../types/fields';
 
@@ -14,4 +14,4 @@ const mapDispatchToProps = {
   onChange: onChange
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ComboboxMultiSelector);
+export default connect(mapStateToProps, mapDispatchToProps)(TreeSelector);


### PR DESCRIPTION
- Display the URL instead of the region in card mode
    Since the region is now a map and cannot be displayed with `toString()`
- Use a tree selector instead of combobox selector for the region